### PR TITLE
feat: handle cancel command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2893,8 +2893,8 @@
       }
     },
     "mathquill": {
-      "version": "git+https://git@github.com/Khan/mathquill.git#a9ae54e057c5c1acc8244a5627acbff29901d992",
-      "from": "git+https://git@github.com/Khan/mathquill.git#a9ae54e057c5c1acc8244a5627acbff29901d992",
+      "version": "git+https://git@github.com/virtual-teacher/mathquill.git#60938076dce605f5744c7a115c37f836710e513d",
+      "from": "git+https://git@github.com/virtual-teacher/mathquill.git#60938076dce605f5744c7a115c37f836710e513d",
       "requires": {
         "pjs": "3.x"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@matejmazur/react-katex": "^3.1.3",
     "jquery": "2.1.1",
     "katex": "^0.13.5",
-    "mathquill": "git+https://git@github.com/Khan/mathquill.git#a9ae54e057c5c1acc8244a5627acbff29901d992",
+    "mathquill": "git+https://git@github.com/virtual-teacher/mathquill.git#60938076dce605f5744c7a115c37f836710e513d",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/src/mathquill.css
+++ b/src/mathquill.css
@@ -407,6 +407,9 @@
   filter: FlipH;
   -ms-filter: "FlipH";
 }
+.mq-cancel {
+  background: linear-gradient(135deg, rgba(0, 0, 0, 0) calc(50% - 1px), black calc(50%), rgba(0, 0, 0, 0) calc(50% + 1px));
+}
 .mq-math-mode .mq-selection,
 .mq-editable-field .mq-selection,
 .mq-math-mode .mq-selection .mq-non-leaf,


### PR DESCRIPTION
uses forked version of Khan mathquill https://github.com/Khan/mathquill/compare/master...virtual-teacher:master with added \cancel command. 

![Screenshot from 2021-07-06 14-10-53](https://user-images.githubusercontent.com/8168459/124597648-03655300-de64-11eb-8d52-002d928b72db.png)
